### PR TITLE
Fixes (DiscoElysion to db.json, Dan Mumford triggers)

### DIFF
--- a/db.json
+++ b/db.json
@@ -3940,6 +3940,11 @@
     "version": "2",
     "style": "digital art",
     "homepage": "https://civitai.com/models/4567/v2-updated-flonixs-dan-mumford-style",
+    "trigger": [
+        "by dan mumford",
+        "in the style of dan mumford",
+        "DanMumford Style"
+    ],
     "nsfw": false,
     "download_all": false,
     "requires": [

--- a/db.json
+++ b/db.json
@@ -6261,6 +6261,40 @@
       },
       "available": false
     },
+  "Disco Elysium": {
+    "name": "Disco Elysium",
+    "baseline": "stable diffusion 1",
+    "type": "ckpt",
+    "description": "Trained on the character portraits from the game Disco Elysium. Can also do great backgrounds, able to be used without a trigger",
+    "version": "1",
+    "style": "artistic",
+    "trigger": [
+      "discoelysium style"
+    ],
+    "homepage": "https://huggingface.co/nitrosocke/disco-elysium",
+    "nsfw": false,
+    "download_all": false,
+    "config": {
+      "files": [
+        {
+          "path": "discoElysium.ckpt",
+          "md5sum": "e6cd877a184d7d04ab9a9ec75ff9a3fb",
+          "sha256sum": "094f1e476f7703566955c2ba9ea6ec55e55929e82790b4646fd41d5f8632f5f5"
+        },
+        {
+          "path": "v1-inference.yaml"
+        }
+      ],
+      "download": [
+        {
+          "file_name": "discoElysium.ckpt",
+          "file_path": "",
+          "file_url": "https://huggingface.co/nitrosocke/disco-elysium/resolve/main/discoElysium-pruned.ckpt"
+        }
+      ]
+    },
+    "available": false
+  },
   "Something": {
       "name": "Something",
       "baseline": "stable diffusion 1",

--- a/stable_diffusion.json
+++ b/stable_diffusion.json
@@ -3833,6 +3833,11 @@
       "version": "2",
       "style": "artistic",
       "homepage": "https://civitai.com/models/4567/v2-updated-flonixs-dan-mumford-style",
+      "trigger": [
+          "by dan mumford",
+          "in the style of dan mumford",
+          "DanMumford Style"
+      ],
       "nsfw": false,
       "download_all": false,
       "config": {


### PR DESCRIPTION
Disco Elysium is missing from db.json entirely, and Dan Mumford lacks triggers. This fixes that.

I used all 3 triggers in my Dan Mumford showcase (not yet uploaded), and it worked that way.

Triggers that worked well for me, if you want to edit those:
[![image](https://i.imgur.com/RddjL6xs.png)](https://i.imgur.com/RddjL6x.png)
[`(by dan mumford, in the style of dan mumford, DanMumford Style:1.3), (epic illustration, dramatic lighting, intricate, low detail, thick contours), psychedelic colors, a frog prince`](https://tinybots.net/artbot?i=n8_AbuHDMqM)

[![image](https://i.imgur.com/JpMvrMls.png)](https://i.imgur.com/JpMvrMl.png)
[`(by dan mumford, in the style of dan mumford, DanMumford Style:1.3), (epic illustration, dramatic lighting, intricate, low detail, thick contours), psychedelic colors, a cute kitten`](https://tinybots.net/artbot?i=rvdtpoTADvN)