### PR TITLE
feat: adds sha256sum to all model files

### DIFF
--- a/blip.json
+++ b/blip.json
@@ -5,7 +5,8 @@
     "config": {
       "files": [
         {
-          "path": "model__base_caption.pth"
+          "path": "model__base_caption.pth",
+          "sha256sum": "96ac8749bd0a568c274ebe302b3a3748ab9be614c737f3d8c529697139174086"
         }
       ],
       "download": [
@@ -24,7 +25,8 @@
     "config": {
       "files": [
         {
-          "path": "model_large_caption.pth"
+          "path": "model_large_caption.pth",
+          "sha256sum": "0d79b3b7c41478b5fe55c35b73ca6f3525a09708289371c6c0fac641e588287e"
         }
       ],
       "download": [

--- a/clip.json
+++ b/clip.json
@@ -5,7 +5,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "ViT-L-14.pt"
+					"path": "ViT-L-14.pt",
+					"sha256sum": "b8cca3fd41ae0c99ba7e8951adf17d267cdb84cd88be6f7c2e0eca1737a03836"
 				}
 			],
 			"download": [

--- a/codeformer.json
+++ b/codeformer.json
@@ -8,7 +8,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "CodeFormers.pth"
+					"path": "CodeFormers.pth",
+					"sha256sum": "1009e537e0c2a07d4cabce6355f53cb66767cd4b4297ec7a4a64ca4b8a5684b7"
 				}
 			],
 			"download": [

--- a/controlnet.json
+++ b/controlnet.json
@@ -10,7 +10,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "diff_control_sd21_canny_fp16.safetensors"
+					"path": "diff_control_sd21_canny_fp16.safetensors",
+					"sha256sum": "7b2c5d972b6212bb9185e5860e66edd29eeeaeb98d43877688e20c156e196ce4"
 				},
 				{
 					"path": "cldm_v21.yaml"
@@ -37,7 +38,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "diff_control_sd21_depth_fp16.safetensors"
+					"path": "diff_control_sd21_depth_fp16.safetensors",
+					"sha256sum": "ed33ec158b6ea3bf61494ee71adc16d45886d5f6611d108345a184ebe7d08d81"
 				},
 				{
 					"path": "cldm_v21.yaml"
@@ -64,7 +66,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "diff_control_sd21_hed_fp16.safetensors"
+					"path": "diff_control_sd21_hed_fp16.safetensors",
+					"sha256sum": "c2f7b28a3ba62c372ad8a1baa875ddbecbd0f9f28b899ecd1c6add2c7b71f7cf"
 				},
 				{
 					"path": "cldm_v21.yaml"
@@ -91,7 +94,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "control_openpose_fp21.safetensors"
+					"path": "control_openpose_fp21.safetensors",
+					"sha256sum": "9d78ae69920502b7dcbf39cd2ec55c9b91b8852ef0248c9bce1624d972f830c5"
 				},
 				{
 					"path": "cldm_v21.yaml"
@@ -118,7 +122,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "control_scribble_fp21.safetensors"
+					"path": "control_scribble_fp21.safetensors",
+					"sha256sum": "7b2ec6479676b52beb8bd22041f6cabbd1a8a16aac7d2d1a3f0e9121edef7b5e"
 				},
 				{
 					"path": "cldm_v21.yaml"
@@ -145,7 +150,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "control_scribble_fp21.safetensors"
+					"path": "control_scribble_fp21.safetensors",
+					"sha256sum": "7b2ec6479676b52beb8bd22041f6cabbd1a8a16aac7d2d1a3f0e9121edef7b5e"
 				},
 				{
 					"path": "cldm_v21.yaml"
@@ -172,7 +178,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "diff_control_sd15_canny_fp16.safetensors"
+					"path": "diff_control_sd15_canny_fp16.safetensors",
+					"sha256sum": "231ce6b2760538a3fb77b7cdc40983d460a91a95ab526f920b08f5e750748d9c"
 				},
 				{
 					"path": "cldm_v15.yaml"
@@ -199,7 +206,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "diff_control_sd15_depth_fp16.safetensors"
+					"path": "diff_control_sd15_depth_fp16.safetensors",
+					"sha256sum": "8b00f19f3f400e3791081ba35c1c615e975d88f5338e7f1bbe09e06465dabc00"
 				},
 				{
 					"path": "cldm_v15.yaml"
@@ -226,7 +234,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "diff_control_sd15_hed_fp16.safetensors"
+					"path": "diff_control_sd15_hed_fp16.safetensors",
+					"sha256sum": "b0d250e550cedad78abf96431bb298f23573c6739b57b93475390a5529b85e52"
 				},
 				{
 					"path": "cldm_v15.yaml"
@@ -253,7 +262,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "control_mlsd_fp16.safetensors"
+					"path": "control_mlsd_fp16.safetensors",
+					"sha256sum": "948fe030361fad35b974e4d112b0ac94df41d7ab61d7847ad7e7b9a98648cf25"
 				},
 				{
 					"path": "cldm_v15.yaml"
@@ -280,7 +290,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "control_mlsd_fp16.safetensors"
+					"path": "control_mlsd_fp16.safetensors",
+					"sha256sum": "948fe030361fad35b974e4d112b0ac94df41d7ab61d7847ad7e7b9a98648cf25"
 				},
 				{
 					"path": "cldm_v15.yaml"
@@ -307,7 +318,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "control_normal_fp16.safetensors"
+					"path": "control_normal_fp16.safetensors",
+					"sha256sum": "1007949f163820f5ba324fd78b674fd04423c62ac6b8db1e896b7bf0ab24422c"
 				},
 				{
 					"path": "cldm_v15.yaml"
@@ -334,7 +346,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "control_openpose_fp16.safetensors"
+					"path": "control_openpose_fp16.safetensors",
+					"sha256sum": "ac1d356292486bbb8d88c67b1099a2b254008b7213149cd874f9506dff81d8da"
 				},
 				{
 					"path": "cldm_v15.yaml"
@@ -361,7 +374,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "control_scribble_fp16.safetensors"
+					"path": "control_scribble_fp16.safetensors",
+					"sha256sum": "b8be265a72b739f809e461adf985051c925c21e9e22e86987a1519191916fc8d"
 				},
 				{
 					"path": "cldm_v15.yaml"
@@ -388,7 +402,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "control_scribble_fp16.safetensors"
+					"path": "control_scribble_fp16.safetensors",
+					"sha256sum": "b8be265a72b739f809e461adf985051c925c21e9e22e86987a1519191916fc8d"
 				},
 				{
 					"path": "cldm_v15.yaml"
@@ -415,7 +430,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "control_seg_fp16.safetensors"
+					"path": "control_seg_fp16.safetensors",
+					"sha256sum": "2471479e29acd24f426ab4aa9cc1598d98d261c3621c91ac70042cdab6cded85"
 				},
 				{
 					"path": "cldm_v15.yaml"

--- a/esrgan.json
+++ b/esrgan.json
@@ -8,7 +8,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "RealESRGAN_x4plus.pth"
+					"path": "RealESRGAN_x4plus.pth",
+					"sha256sum": "4fa0d38905f75ac06eb49a7951b426670021be3018265fd191d2125df9d682f1"
 				}
 			],
 			"download": [
@@ -30,7 +31,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "RealESRGAN_x4plus_anime_6B.pth"
+					"path": "RealESRGAN_x4plus_anime_6B.pth",
+					"sha256sum": "f872d837d3c90ed2e05227bed711af5671a6fd1c9f7d7e91c911a61f155e99da"
 				}
 			],
 			"download": [
@@ -52,7 +54,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "RealESRGAN_x2plus.pth"
+					"path": "RealESRGAN_x2plus.pth",
+					"sha256sum": "49fafd45f8fd7aa8d31ab2a22d14d91b536c34494a5cfe31eb5d89c2fa266abb"
 				}
 			],
 			"download": [
@@ -74,7 +77,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "NMKD_Siax.pth"
+					"path": "NMKD_Siax.pth",
+					"sha256sum": "65fece06e1ccb48853242aa972bdf00ad07a7dd8938d2dcbdf4221b59f6372ce"
 				}
 			],
 			"download": [
@@ -96,7 +100,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "4x_AnimeSharp.pth"
+					"path": "4x_AnimeSharp.pth",
+					"sha256sum": "e7a7de2dafd7331c1992862bbbcd9e9712a9f9f8e6303f0aaa59b4341d359bab"
 				}
 			],
 			"download": [
@@ -118,7 +123,8 @@
 		"config": {
 			"files": [
 				{
-					"path": "4x_NMKD-Superscale-SP_178000_G.pth"
+					"path": "4x_NMKD-Superscale-SP_178000_G.pth",
+					"sha256sum": "1d1b0078fe71446e0469d8d4df59e96baa80d83cda600d68237d655830821bcc"
 				}
 			],
 			"download": [

--- a/gfpgan.json
+++ b/gfpgan.json
@@ -8,13 +8,16 @@
 		"config": {
 			"files": [
 				{
-					"path": "GFPGANv1.4.pth"
+					"path": "GFPGANv1.4.pth",
+					"sha256sum": "e2cd4703ab14f4d01fd1383a8a8b266f9a5833dacee8e6a79d3bf21a1b6be5ad"
 				},
 				{
-					"path": "detection_Resnet50_Final.pth"
+					"path": "detection_Resnet50_Final.pth",
+					"sha256sum": "6d1de9c2944f2ccddca5f5e010ea5ae64a39845a86311af6fdf30841b0a5a16d"
 				},
 				{
-					"path": "parsing_parsenet.pth"
+					"path": "parsing_parsenet.pth",
+					"sha256sum": "3d558d8d0e42c20224f13cf5a29c79eba2d59913419f945545d8cf7b72920de2"
 				}
 			],
 			"download": [

--- a/safety_checker.json
+++ b/safety_checker.json
@@ -7,6 +7,7 @@
 			"files": [
 				{
 					"path": "pytorch_model.bin",
+					"sha256sum": "64B8393F1AFD5A0C1ED2AA5F341FA7C08286839A48F3743162A76A2835C808BD",
 					"md5sum": "dbbcb50d4df4572a720b104fae1e8187"
 				},
 				{


### PR DESCRIPTION
All `*.pt`, `*.ckpt` and `*.safetensors` across all model categories should now have a sha256 defined as of this change set.