### PR TITLE
fix: safety_checker sha256 to lowercase

### DIFF
--- a/safety_checker.json
+++ b/safety_checker.json
@@ -7,7 +7,7 @@
 			"files": [
 				{
 					"path": "pytorch_model.bin",
-					"sha256sum": "64B8393F1AFD5A0C1ED2AA5F341FA7C08286839A48F3743162A76A2835C808BD",
+					"sha256sum": "64b8393f1afd5a0c1ed2aa5f341fa7c08286839a48f3743162a76a2835c808bd",
 					"md5sum": "dbbcb50d4df4572a720b104fae1e8187"
 				},
 				{


### PR DESCRIPTION
Nataili workers are unprepared for an all upper case sha256sum, as was present.